### PR TITLE
FT2023-346 : Created custom module to create custom entity type .

### DIFF
--- a/web/modules/custom/entity_movie/config/install/core.entity_form_display.node.movie_info.default.yml
+++ b/web/modules/custom/entity_movie/config/install/core.entity_form_display.node.movie_info.default.yml
@@ -1,0 +1,26 @@
+# core.entity_form_display.node.movie_info.default.yml
+langcode: en
+status: true
+dependencies:
+    config:
+        - field.field.node.movie_info.body
+        - field.field.node.movie_info.field_price
+        - field.field.node.movie_info.field_movie_image
+        - node.type.movie_info
+    module:
+        - text
+        - user
+id: node.movie_info.default
+targetEntityType: node
+bundle: movie_info
+mode: default
+content:
+    body:
+        label: hidden
+        type: text_textarea_with_summary
+        weight: 101
+        settings: {  }
+        third_party_settings: {  }
+    links:
+        weight: 100
+hidden: {  }

--- a/web/modules/custom/entity_movie/config/install/core.entity_view_display.node.movie_info.default.yml
+++ b/web/modules/custom/entity_movie/config/install/core.entity_view_display.node.movie_info.default.yml
@@ -1,0 +1,26 @@
+# core.entity_view_display.node.movie_info.default.yml
+langcode: en
+status: true
+dependencies:
+    config:
+        - field.field.node.movie_info.body
+        - field.field.node.movie_info.field_price
+        - field.field.node.movie_info.field_movie_image
+        - node.type.movie_info
+    module:
+        - text
+        - user
+id: node.movie_info.default
+targetEntityType: node
+bundle: movie_info
+mode: default
+content:
+    body:
+        label: hidden
+        type: text_default
+        weight: 101
+        settings: {  }
+        third_party_settings: {  }
+    links:
+        weight: 100
+hidden: {  }

--- a/web/modules/custom/entity_movie/config/install/core.entity_view_display.node.movie_info.teaser.yml
+++ b/web/modules/custom/entity_movie/config/install/core.entity_view_display.node.movie_info.teaser.yml
@@ -1,0 +1,26 @@
+# core.entity_view_display.node.movie_info.teaser.yml
+langcode: en
+status: true
+dependencies:
+    config:
+        - core.entity_view_mode.node.teaser
+        - field.field.node.movie_info.body
+        - node.type.movie_info
+    module:
+        - text
+        - user
+id: node.movie_info.teaser
+targetEntityType: node
+bundle: movie_info
+mode: teaser
+content:
+    body:
+        label: hidden
+        type: text_summary_or_trimmed
+        weight: 101
+        settings:
+            trim_length: 600
+        third_party_settings: {  }
+    links:
+        weight: 100
+hidden: {  }

--- a/web/modules/custom/entity_movie/config/install/field.field.node.movie_info.body.yml
+++ b/web/modules/custom/entity_movie/config/install/field.field.node.movie_info.body.yml
@@ -1,0 +1,22 @@
+# field.field.node.movie_info.body.yml
+langcode: en
+status: true
+dependencies:
+    config:
+        - field.storage.node.body
+        - node.type.movie_info
+    module:
+        - text
+id: node.movie_info.body
+field_name: body
+entity_type: node
+bundle: movie_info
+label: Body
+description: 'More specific information about the Movies.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+    display_summary: true
+field_type: text_with_summary

--- a/web/modules/custom/entity_movie/config/install/field.field.node.movie_info.field_movie_image.yml
+++ b/web/modules/custom/entity_movie/config/install/field.field.node.movie_info.field_movie_image.yml
@@ -1,0 +1,27 @@
+# field.field.node.car_brand.field_price.yml
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_movie_image
+    - node.type.movie_info
+  module:
+    - image
+id: node.movie_info.field_movie_image
+field_name: movie_image
+entity_type: node
+bundle: movie_info
+label: 'Image'
+description: 'Image of the Movie'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: 'entity_movie/images'
+  file_extensions: 'png jpg jpeg'
+  max_filesize: '10MB'
+  max_resolution: '1920x1080'
+  alt_field: true
+  title_field: true
+field_type: image

--- a/web/modules/custom/entity_movie/config/install/field.field.node.movie_info.field_price.yml
+++ b/web/modules/custom/entity_movie/config/install/field.field.node.movie_info.field_price.yml
@@ -1,0 +1,20 @@
+# field.field.node.car_brand.field_price.yml
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_price
+    - node.type.movie_info
+id: node.movie_info.field_price
+field_name: movie_price
+entity_type: node
+bundle: movie_info
+label: 'Price'
+description: 'Price of the Movie'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+field_type: decimal

--- a/web/modules/custom/entity_movie/config/install/field.storage.node.field_movie_image.yml
+++ b/web/modules/custom/entity_movie/config/install/field.storage.node.field_movie_image.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - image
+id: node.field_movie_image
+field_name: movie_image
+entity_type: node
+type: image
+settings: {  }
+module: image
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/entity_movie/config/install/field.storage.node.field_price.yml
+++ b/web/modules/custom/entity_movie/config/install/field.storage.node.field_price.yml
@@ -1,0 +1,18 @@
+# field.storage.node.field_price.yml
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_price
+field_name: movie_price
+entity_type: node
+type: decimal
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/entity_movie/config/install/node.type.movie_info.yml
+++ b/web/modules/custom/entity_movie/config/install/node.type.movie_info.yml
@@ -1,0 +1,14 @@
+# node.type.movie_info.yml
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - entity_movie # This is the name of the module we're using for this example
+name: 'Movie'
+type: movie_info
+description: 'Content type that can be used to provide additional information on <em>Movies</em>'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: true

--- a/web/modules/custom/entity_movie/config/schema/entity_movie.entity_type.schema.yml
+++ b/web/modules/custom/entity_movie/config/schema/entity_movie.entity_type.schema.yml
@@ -1,0 +1,12 @@
+entity_movie.movie_type.*:
+  type: config_entity
+  label: 'Movie type config'
+  mapping:
+    id:
+      type: string
+      label: 'ID'
+    label:
+      type: label
+      label: 'Label'
+    uuid:
+      type: string

--- a/web/modules/custom/entity_movie/config/schema/entity_movie.schema.yml
+++ b/web/modules/custom/entity_movie/config/schema/entity_movie.schema.yml
@@ -1,0 +1,14 @@
+entity_movie.movie_configuration.*:
+  type: config_entity
+  label: Movie Configuration
+  mapping:
+    id:
+      type: string
+      label: ID
+    label:
+      type: label
+      label: Label
+    uuid:
+      type: string
+    description:
+      type: string

--- a/web/modules/custom/entity_movie/entity_movie.info.yml
+++ b/web/modules/custom/entity_movie/entity_movie.info.yml
@@ -1,0 +1,6 @@
+name: entity_movie
+type: module
+description: Create a custom module to create a custom entity type Movie.
+package: Custom Module
+core_version_requirement: ^10
+configure: entity.movie_configuration.collection

--- a/web/modules/custom/entity_movie/entity_movie.links.action.yml
+++ b/web/modules/custom/entity_movie/entity_movie.links.action.yml
@@ -1,0 +1,17 @@
+movie.type_add:
+  title: 'Add movie type'
+  route_name: entity.movie_type.add_form
+  appears_on:
+    - entity.movie_type.collection
+
+movie.add_page:
+  title: 'Add movie'
+  route_name: entity.movie.add_page
+  appears_on:
+    - entity.movie.collection
+
+entity.movie_configuration.add_form:
+  route_name: 'entity.movie_configuration.add_form'
+  title: 'Add movie configuration'
+  appears_on:
+    - entity.movie_configuration.collection

--- a/web/modules/custom/entity_movie/entity_movie.links.contextual.yml
+++ b/web/modules/custom/entity_movie/entity_movie.links.contextual.yml
@@ -1,0 +1,10 @@
+entity.movie.edit_form:
+  route_name: entity.movie.edit_form
+  group: movie
+  title: Edit
+
+entity.movie.delete_form:
+  route_name: entity.movie.delete_form
+  group: movie
+  title: Delete
+  weight: 10

--- a/web/modules/custom/entity_movie/entity_movie.links.menu.yml
+++ b/web/modules/custom/entity_movie/entity_movie.links.menu.yml
@@ -1,0 +1,11 @@
+entity.movie_type.collection:
+  title: 'Movie types'
+  description: 'Manage and CRUD actions on Movie type.'
+  parent: system.admin_structure
+  route_name: entity.movie_type.collection
+
+entity.movie_configuration.overview:
+  title: Movie Configurations
+  parent: system.admin_structure
+  description: 'List of movie configurations to extend site functionality.'
+  route_name: entity.movie_configuration.collection

--- a/web/modules/custom/entity_movie/entity_movie.links.task.yml
+++ b/web/modules/custom/entity_movie/entity_movie.links.task.yml
@@ -1,0 +1,26 @@
+entity.movie.view:
+  title: 'View'
+  route_name: entity.movie.canonical
+  base_route: entity.movie.canonical
+entity.movie.edit_form:
+  title: 'Edit'
+  route_name: entity.movie.edit_form
+  base_route: entity.movie.canonical
+entity.movie.delete_form:
+  title: 'Delete'
+  route_name: entity.movie.delete_form
+  base_route: entity.movie.canonical
+  weight: 10
+entity.movie.collection:
+  title: 'Movies'
+  route_name: entity.movie.collection
+  base_route: system.admin_content
+  weight: 10
+entity.movie_type.edit_form:
+  title: 'Edit'
+  route_name: entity.movie_type.edit_form
+  base_route: entity.movie_type.edit_form
+entity.movie_type.collection:
+  title: 'List'
+  route_name: entity.movie_type.collection
+  base_route: entity.movie_type.collection

--- a/web/modules/custom/entity_movie/entity_movie.module
+++ b/web/modules/custom/entity_movie/entity_movie.module
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @file
+ * Provides a movie entity type.
+ */
+
+use Drupal\Core\Render\Element;
+use Drupal\user\UserInterface;
+
+/**
+ * Implements hook_theme().
+ */
+function entity_movie_theme() {
+  return [
+    'movie' => [
+      'render element' => 'elements',
+    ],
+  ];
+}
+
+/**
+ * Prepares variables for movie templates.
+ *
+ * Default template: movie.html.twig.
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - elements: An associative array containing the movie information and any
+ *     fields attached to the entity.
+ *   - attributes: HTML attributes for the containing element.
+ */
+function template_preprocess_movie(array &$variables) {
+  $variables['view_mode'] = $variables['elements']['#view_mode'];
+  foreach (Element::children($variables['elements']) as $key) {
+    $variables['content'][$key] = $variables['elements'][$key];
+  }
+}
+
+/**
+ * Implements hook_user_cancel().
+ */
+function entity_movie_user_cancel($edit, UserInterface $account, $method) {
+  switch ($method) {
+    case 'user_cancel_block_unpublish':
+      // Unpublish movies.
+      $storage = \Drupal::entityTypeManager()->getStorage('movie');
+      $movie_ids = $storage->getQuery()
+        ->condition('uid', $account->id())
+        ->condition('status', 1)
+        ->execute();
+      foreach ($storage->loadMultiple($movie_ids) as $movie) {
+        $movie->set('status', FALSE);
+        $movie->save();
+      }
+      break;
+
+    case 'user_cancel_reassign':
+      // Anonymize movies.
+      $storage = \Drupal::entityTypeManager()->getStorage('movie');
+      $movie_ids = $storage->getQuery()
+        ->condition('uid', $account->id())
+        ->execute();
+      foreach ($storage->loadMultiple($movie_ids) as $movie) {
+        $movie->setOwnerId(0);
+        $movie->save();
+      }
+      break;
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_predelete() for user entities.
+ */
+function entity_movie_user_predelete(UserInterface $account) {
+  // Delete movies.
+  $storage = \Drupal::entityTypeManager()->getStorage('movie');
+  $movie_ids = $storage->getQuery()
+    ->condition('uid', $account->id())
+    ->execute();
+  $movies = $storage->loadMultiple($movie_ids);
+  $storage->delete($movies);
+}

--- a/web/modules/custom/entity_movie/entity_movie.permissions.yml
+++ b/web/modules/custom/entity_movie/entity_movie.permissions.yml
@@ -1,0 +1,7 @@
+administer movie types:
+  title: 'Administer movie types'
+  description: 'Maintain the types of movie entity.'
+  restrict access: true
+
+administer movie_configuration:
+  title: 'Administer movie configuration'

--- a/web/modules/custom/entity_movie/entity_movie.routing.yml
+++ b/web/modules/custom/entity_movie/entity_movie.routing.yml
@@ -1,0 +1,31 @@
+entity.movie_configuration.collection:
+  path: '/admin/structure/movie-configuration'
+  defaults:
+    _entity_list: 'movie_configuration'
+    _title: 'Movie Configuration configuration'
+  requirements:
+    _permission: 'administer movie_configuration'
+
+entity.movie_configuration.add_form:
+  path: '/admin/structure/movie_configuration/add'
+  defaults:
+    _entity_form: 'movie_configuration.add'
+    _title: 'Add a movie configuration'
+  requirements:
+    _permission: 'administer movie_configuration'
+
+entity.movie_configuration.edit_form:
+  path: '/admin/structure/movie-configuration/{movie_configuration}'
+  defaults:
+    _entity_form: 'movie_configuration.edit'
+    _title: 'Edit a movie configuration'
+  requirements:
+    _permission: 'administer movie_configuration'
+
+entity.movie_configuration.delete_form:
+  path: '/admin/structure/movie-configuration/{movie_configuration}/delete'
+  defaults:
+    _entity_form: 'movie_configuration.delete'
+    _title: 'Delete a movie configuration'
+  requirements:
+    _permission: 'administer movie_configuration'

--- a/web/modules/custom/entity_movie/entity_movie.services.yml
+++ b/web/modules/custom/entity_movie/entity_movie.services.yml
@@ -1,0 +1,7 @@
+services:
+  entity_movie.uninstall_validator:
+    class: Drupal\entity_movie\MovieUninstallValidator
+    tags:
+      - { name: module_install.uninstall_validator }
+    arguments: ['@entity_type.manager', '@string_translation']
+    lazy: true

--- a/web/modules/custom/entity_movie/src/Entity/Movie.php
+++ b/web/modules/custom/entity_movie/src/Entity/Movie.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Drupal\entity_movie\Entity;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityChangedTrait;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\entity_movie\MovieInterface;
+use Drupal\user\EntityOwnerTrait;
+
+/**
+ * Defines the movie entity class.
+ *
+ * @ContentEntityType(
+ *   id = "movie",
+ *   label = @Translation("Movie"),
+ *   label_collection = @Translation("Movies"),
+ *   label_singular = @Translation("movie"),
+ *   label_plural = @Translation("movies"),
+ *   label_count = @PluralTranslation(
+ *     singular = "@count movies",
+ *     plural = "@count movies",
+ *   ),
+ *   bundle_label = @Translation("Movie type"),
+ *   handlers = {
+ *     "list_builder" = "Drupal\entity_movie\MovieListBuilder",
+ *     "views_data" = "Drupal\views\EntityViewsData",
+ *     "form" = {
+ *       "add" = "Drupal\entity_movie\Form\MovieForm",
+ *       "edit" = "Drupal\entity_movie\Form\MovieForm",
+ *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm",
+ *     },
+ *     "route_provider" = {
+ *       "html" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider",
+ *     }
+ *   },
+ *   base_table = "movie",
+ *   admin_permission = "administer movie types",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "bundle" = "bundle",
+ *     "label" = "label",
+ *     "uuid" = "uuid",
+ *     "owner" = "uid",
+ *   },
+ *   links = {
+ *     "collection" = "/admin/content/movie",
+ *     "add-form" = "/movie/add/{movie_type}",
+ *     "add-page" = "/movie/add",
+ *     "canonical" = "/movie/{movie}",
+ *     "edit-form" = "/movie/{movie}/edit",
+ *     "delete-form" = "/movie/{movie}/delete",
+ *   },
+ *   bundle_entity_type = "movie_type",
+ *   field_ui_base_route = "entity.movie_type.edit_form",
+ * )
+ */
+class Movie extends ContentEntityBase implements MovieInterface {
+
+  use EntityChangedTrait;
+  use EntityOwnerTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preSave(EntityStorageInterface $storage) {
+    parent::preSave($storage);
+    if (!$this->getOwnerId()) {
+      // If no owner has been set explicitly, make the anonymous user the owner.
+      $this->setOwnerId(0);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['label'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Label'))
+      ->setRequired(TRUE)
+      ->setSetting('max_length', 255)
+      ->setDisplayOptions('form', [
+        'type' => 'string_textfield',
+        'weight' => -5,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayOptions('view', [
+        'label' => 'hidden',
+        'type' => 'string',
+        'weight' => -5,
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['status'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Status'))
+      ->setDefaultValue(TRUE)
+      ->setSetting('on_label', 'Enabled')
+      ->setDisplayOptions('form', [
+        'type' => 'boolean_checkbox',
+        'settings' => [
+          'display_label' => FALSE,
+        ],
+        'weight' => 0,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayOptions('view', [
+        'type' => 'boolean',
+        'label' => 'above',
+        'weight' => 0,
+        'settings' => [
+          'format' => 'enabled-disabled',
+        ],
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['description'] = BaseFieldDefinition::create('text_long')
+      ->setLabel(t('Description'))
+      ->setDisplayOptions('form', [
+        'type' => 'text_textarea',
+        'weight' => 10,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayOptions('view', [
+        'type' => 'text_default',
+        'label' => 'above',
+        'weight' => 10,
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['uid'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Author'))
+      ->setSetting('target_type', 'user')
+      ->setDefaultValueCallback(static::class . '::getDefaultEntityOwner')
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+        'settings' => [
+          'match_operator' => 'CONTAINS',
+          'size' => 60,
+          'placeholder' => '',
+        ],
+        'weight' => 15,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'author',
+        'weight' => 15,
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['created'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Authored on'))
+      ->setDescription(t('The time that the movie was created.'))
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'timestamp',
+        'weight' => 20,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayOptions('form', [
+        'type' => 'datetime_timestamp',
+        'weight' => 20,
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['changed'] = BaseFieldDefinition::create('changed')
+      ->setLabel(t('Changed'))
+      ->setDescription(t('The time that the movie was last edited.'));
+
+    return $fields;
+  }
+
+}

--- a/web/modules/custom/entity_movie/src/Entity/MovieConfiguration.php
+++ b/web/modules/custom/entity_movie/src/Entity/MovieConfiguration.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\entity_movie\Entity;
+
+use Drupal\Core\Config\Entity\ConfigEntityBase;
+use Drupal\entity_movie\MovieConfigurationInterface;
+
+/**
+ * Defines the movie configuration entity type.
+ *
+ * @ConfigEntityType(
+ *   id = "movie_configuration",
+ *   label = @Translation("Movie Configuration"),
+ *   label_collection = @Translation("Movie Configurations"),
+ *   label_singular = @Translation("movie configuration"),
+ *   label_plural = @Translation("movie configurations"),
+ *   label_count = @PluralTranslation(
+ *     singular = "@count movie configuration",
+ *     plural = "@count movie configurations",
+ *   ),
+ *   handlers = {
+ *     "list_builder" = "Drupal\entity_movie\MovieConfigurationListBuilder",
+ *     "form" = {
+ *       "add" = "Drupal\entity_movie\Form\MovieConfigurationForm",
+ *       "edit" = "Drupal\entity_movie\Form\MovieConfigurationForm",
+ *       "delete" = "Drupal\Core\Entity\EntityDeleteForm"
+ *     }
+ *   },
+ *   config_prefix = "movie_configuration",
+ *   admin_permission = "administer movie_configuration",
+ *   links = {
+ *     "collection" = "/admin/structure/movie-configuration",
+ *     "add-form" = "/admin/structure/movie-configuration/add",
+ *     "edit-form" = "/admin/structure/movie-configuration/{movie_configuration}",
+ *     "delete-form" = "/admin/structure/movie-configuration/{movie_configuration}/delete"
+ *   },
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "label",
+ *      "year" = "year",
+ *      "movie" = "movie",
+ *      "uuid" = "uuid"
+ *   },
+ *   config_export = {
+ *     "id",
+ *     "label",
+ *     "description",
+ *      "year",
+ *      "movie",
+ *   }
+ * )
+ */
+class MovieConfiguration extends ConfigEntityBase implements MovieConfigurationInterface {
+
+  /**
+   * The movie configuration ID.
+   *
+   * @var string
+   */
+  protected $id;
+
+  /**
+   * The movie configuration label.
+   *
+   * @var string
+   */
+  protected $label;
+
+  /**
+   * The movie configuration status.
+   *
+   * @var bool
+   */
+  protected $status;
+
+  /**
+   * The movie_configuration description.
+   *
+   * @var string
+   */
+  protected $description;
+
+  /**
+   * The year on which movie was released.
+   *
+   * @var mixed
+   */
+  protected $year;
+
+}

--- a/web/modules/custom/entity_movie/src/Entity/MovieType.php
+++ b/web/modules/custom/entity_movie/src/Entity/MovieType.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\entity_movie\Entity;
+
+use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
+
+/**
+ * Defines the Movie type configuration entity.
+ *
+ * @ConfigEntityType(
+ *   id = "movie_type",
+ *   label = @Translation("Movie type"),
+ *   label_collection = @Translation("Movie types"),
+ *   label_singular = @Translation("movie type"),
+ *   label_plural = @Translation("movies types"),
+ *   label_count = @PluralTranslation(
+ *     singular = "@count movies type",
+ *     plural = "@count movies types",
+ *   ),
+ *   handlers = {
+ *     "form" = {
+ *       "add" = "Drupal\entity_movie\Form\MovieTypeForm",
+ *       "edit" = "Drupal\entity_movie\Form\MovieTypeForm",
+ *       "delete" = "Drupal\Core\Entity\EntityDeleteForm",
+ *     },
+ *     "list_builder" = "Drupal\entity_movie\MovieTypeListBuilder",
+ *     "route_provider" = {
+ *       "html" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider",
+ *     }
+ *   },
+ *   admin_permission = "administer movie types",
+ *   bundle_of = "movie",
+ *   config_prefix = "movie_type",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "label",
+ *     "uuid" = "uuid"
+ *   },
+ *   links = {
+ *     "add-form" = "/admin/structure/movie_types/add",
+ *     "edit-form" = "/admin/structure/movie_types/manage/{movie_type}",
+ *     "delete-form" = "/admin/structure/movie_types/manage/{movie_type}/delete",
+ *     "collection" = "/admin/structure/movie_types"
+ *   },
+ *   config_export = {
+ *     "id",
+ *     "label",
+ *     "uuid",
+ *   }
+ * )
+ */
+class MovieType extends ConfigEntityBundleBase {
+
+  /**
+   * The machine name of this movie type.
+   *
+   * @var string
+   */
+  protected $id;
+
+  /**
+   * The human-readable name of the movie type.
+   *
+   * @var string
+   */
+  protected $label;
+
+}

--- a/web/modules/custom/entity_movie/src/Form/MovieConfigurationForm.php
+++ b/web/modules/custom/entity_movie/src/Form/MovieConfigurationForm.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\entity_movie\Form;
+
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Movie Configuration form.
+ *
+ * @property \Drupal\entity_movie\MovieConfigurationInterface $entity
+ */
+class MovieConfigurationForm extends EntityForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    $form['label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Award Name'),
+      '#maxlength' => 255,
+      '#default_value' => $this->entity->label(),
+      '#description' => $this->t('Award Name.'),
+      '#required' => TRUE,
+    ];
+    $form['id'] = [
+      '#type' => 'machine_name',
+      '#default_value' => $this->entity->id(),
+      '#machine_name' => [
+        'exists' => '\Drupal\entity_movie\Entity\MovieConfiguration::load',
+      ],
+      '#disabled' => !$this->entity->isNew(),
+    ];
+    $id = $this->entity->get('movie')[0]['target_id'];
+    $form['movie'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Movie Name'),
+      '#target_type' => 'node',
+      '#selection_settings' => ['target_bundles' => ['movie_info']],
+      '#tags' => TRUE,
+      '#size' => 30,
+      '#maxlength' => 1024,
+    // Dependency injection.
+      '#default_value' => $this->entityTypeManager->getStorage('node')->load($id),
+      '#persist' => TRUE,
+    ];
+    $default_year = $this->entity->get('year');
+    $form['year'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Year'),
+      '#default_value' => $default_year,
+      '#description' => $this->t('Year of the award.'),
+      '#required' => TRUE,
+      '#persist' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $result = parent::save($form, $form_state);
+    $message_args = ['%label' => $this->entity->label()];
+    $message = $result == SAVED_NEW
+      ? $this->t('Created new movie configuration %label.', $message_args)
+      : $this->t('Updated movie configuration %label.', $message_args);
+    $this->messenger()->addStatus($message);
+    $form_state->setRedirectUrl($this->entity->toUrl('collection'));
+    return $result;
+  }
+
+}

--- a/web/modules/custom/entity_movie/src/Form/MovieForm.php
+++ b/web/modules/custom/entity_movie/src/Form/MovieForm.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\entity_movie\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form controller for the movie entity edit forms.
+ */
+class MovieForm extends ContentEntityForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $result = parent::save($form, $form_state);
+
+    $entity = $this->getEntity();
+
+    $message_arguments = ['%label' => $entity->toLink()->toString()];
+    $logger_arguments = [
+      '%label' => $entity->label(),
+      'link' => $entity->toLink($this->t('View'))->toString(),
+    ];
+
+    switch ($result) {
+      case SAVED_NEW:
+        $this->messenger()->addStatus($this->t('New movie %label has been created.', $message_arguments));
+        $this->logger('entity_movie')->notice('Created new movie %label', $logger_arguments);
+        break;
+
+      case SAVED_UPDATED:
+        $this->messenger()->addStatus($this->t('The movie %label has been updated.', $message_arguments));
+        $this->logger('entity_movie')->notice('Updated movie %label.', $logger_arguments);
+        break;
+    }
+
+    $form_state->setRedirect('entity.movie.canonical', ['movie' => $entity->id()]);
+
+    return $result;
+  }
+
+}

--- a/web/modules/custom/entity_movie/src/Form/MovieTypeForm.php
+++ b/web/modules/custom/entity_movie/src/Form/MovieTypeForm.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\entity_movie\Form;
+
+use Drupal\Core\Entity\BundleEntityFormBase;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form handler for movie type forms.
+ */
+class MovieTypeForm extends BundleEntityFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    $entity_type = $this->entity;
+    if ($this->operation == 'edit') {
+      $form['#title'] = $this->t('Edit %label movie type', ['%label' => $entity_type->label()]);
+    }
+
+    $form['label'] = [
+      '#title' => $this->t('Label'),
+      '#type' => 'textfield',
+      '#default_value' => $entity_type->label(),
+      '#description' => $this->t('The human-readable name of this movie type.'),
+      '#required' => TRUE,
+      '#size' => 30,
+    ];
+
+    $form['id'] = [
+      '#type' => 'machine_name',
+      '#default_value' => $entity_type->id(),
+      '#maxlength' => EntityTypeInterface::BUNDLE_MAX_LENGTH,
+      '#machine_name' => [
+        'exists' => ['Drupal\entity_movie\Entity\MovieType', 'load'],
+        'source' => ['label'],
+      ],
+      '#description' => $this->t('A unique machine-readable name for this movie type. It must only contain lowercase letters, numbers, and underscores.'),
+    ];
+
+    return $this->protectBundleIdElement($form);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function actions(array $form, FormStateInterface $form_state) {
+    $actions = parent::actions($form, $form_state);
+    $actions['submit']['#value'] = $this->t('Save movie type');
+    $actions['delete']['#value'] = $this->t('Delete movie type');
+    return $actions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $entity_type = $this->entity;
+
+    $entity_type->set('id', trim($entity_type->id()));
+    $entity_type->set('label', trim($entity_type->label()));
+
+    $status = $entity_type->save();
+
+    $t_args = ['%name' => $entity_type->label()];
+    if ($status == SAVED_UPDATED) {
+      $message = $this->t('The movie type %name has been updated.', $t_args);
+    }
+    elseif ($status == SAVED_NEW) {
+      $message = $this->t('The movie type %name has been added.', $t_args);
+    }
+    $this->messenger()->addStatus($message);
+
+    $form_state->setRedirectUrl($entity_type->toUrl('collection'));
+  }
+
+}

--- a/web/modules/custom/entity_movie/src/MovieConfigurationInterface.php
+++ b/web/modules/custom/entity_movie/src/MovieConfigurationInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\entity_movie;
+
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
+
+/**
+ * Provides an interface defining a movie configuration entity type.
+ */
+interface MovieConfigurationInterface extends ConfigEntityInterface {
+
+}

--- a/web/modules/custom/entity_movie/src/MovieConfigurationListBuilder.php
+++ b/web/modules/custom/entity_movie/src/MovieConfigurationListBuilder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\entity_movie;
+
+use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Provides a listing of movie configurations.
+ */
+class MovieConfigurationListBuilder extends ConfigEntityListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['label'] = $this->t('Award Name');
+    $header['movie'] = $this->t('Movie');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    /** @var \Drupal\entity_movie\MovieConfigurationInterface $entity */
+    $entityTypeManager = \Drupal::entityTypeManager();
+    $id = $entity->get('movie')[0]['target_id'];
+    $movie_name = $entityTypeManager->getStorage('node')->load($id)->get('title')->value;
+    $row['label'] = $entity->label();
+    $row['movie'] = $movie_name;
+    return $row + parent::buildRow($entity);
+  }
+
+}

--- a/web/modules/custom/entity_movie/src/MovieInterface.php
+++ b/web/modules/custom/entity_movie/src/MovieInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\entity_movie;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\user\EntityOwnerInterface;
+
+/**
+ * Provides an interface defining a movie entity type.
+ */
+interface MovieInterface extends ContentEntityInterface, EntityOwnerInterface, EntityChangedInterface {
+
+}

--- a/web/modules/custom/entity_movie/src/MovieListBuilder.php
+++ b/web/modules/custom/entity_movie/src/MovieListBuilder.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\entity_movie;
+
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a list controller for the movie entity type.
+ */
+class MovieListBuilder extends EntityListBuilder {
+
+  /**
+   * The date formatter service.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateFormatter;
+
+  /**
+   * Constructs a new MovieListBuilder object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type definition.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
+   *   The entity storage class.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter service.
+   */
+  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, DateFormatterInterface $date_formatter) {
+    parent::__construct($entity_type, $storage);
+    $this->dateFormatter = $date_formatter;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $entity_type,
+      $container->get('entity_type.manager')->getStorage($entity_type->id()),
+      $container->get('date.formatter')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $build['table'] = parent::render();
+
+    $total = $this->getStorage()
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->count()
+      ->execute();
+
+    $build['summary']['#markup'] = $this->t('Total movies: @total', ['@total' => $total]);
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['id'] = $this->t('ID');
+    $header['label'] = $this->t('Label');
+    $header['status'] = $this->t('Status');
+    $header['uid'] = $this->t('Author');
+    $header['created'] = $this->t('Created');
+    $header['changed'] = $this->t('Updated');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    /** @var \Drupal\entity_movie\MovieInterface $entity */
+    $row['id'] = $entity->id();
+    $row['label'] = $entity->toLink();
+    $row['status'] = $entity->get('status')->value ? $this->t('Enabled') : $this->t('Disabled');
+    $row['uid']['data'] = [
+      '#theme' => 'username',
+      '#account' => $entity->getOwner(),
+    ];
+    $row['created'] = $this->dateFormatter->format($entity->get('created')->value);
+    $row['changed'] = $this->dateFormatter->format($entity->getChangedTime());
+    return $row + parent::buildRow($entity);
+  }
+
+}

--- a/web/modules/custom/entity_movie/src/MovieTypeListBuilder.php
+++ b/web/modules/custom/entity_movie/src/MovieTypeListBuilder.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\entity_movie;
+
+use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
+
+/**
+ * Defines a class to build a listing of movie type entities.
+ *
+ * @see \Drupal\entity_movie\Entity\MovieType
+ */
+class MovieTypeListBuilder extends ConfigEntityListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['title'] = $this->t('Label');
+
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    $row['title'] = [
+      'data' => $entity->label(),
+      'class' => ['menu-label'],
+    ];
+
+    return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $build = parent::render();
+
+    $build['table']['#empty'] = $this->t(
+      'No movie types available. <a href=":link">Add movie type</a>.',
+      [':link' => Url::fromRoute('entity.movie_type.add_form')->toString()]
+    );
+
+    return $build;
+  }
+
+}

--- a/web/modules/custom/entity_movie/src/MovieUninstallValidator.php
+++ b/web/modules/custom/entity_movie/src/MovieUninstallValidator.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\entity_movie;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleUninstallValidatorInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Prevents book module from being uninstalled under certain conditions.
+ *
+ * These conditions are when any book nodes exist or there are any book outline
+ * stored.
+ */
+class MovieUninstallValidator implements ModuleUninstallValidatorInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new MovieUninstallValidator.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, TranslationInterface $string_translation) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($module) {
+    $reasons = [];
+    if ($module == 'entity_movie' && $this->hasNodes() != 0) {
+      $reasons[] = $this->t('To uninstall Movie, delete all content that is part of a movie');
+    }
+    return $reasons;
+  }
+
+  /**
+   * Determines if there is any movie nodes posted by user or not.
+   *
+   * @param \Drupal\user\UserInterface $data
+   *   Post Owner.
+   *
+   * @return string
+   *   Count of number of posts.
+   */
+  protected function hasNodes($data = NULL) {
+    $nodes = $this->entityTypeManager->getStorage('node')->getQuery()
+      ->condition('type', 'movie_info')
+      ->accessCheck(TRUE)
+      ->condition('status', 1);
+    if ($data) {
+      $nodes->condition('uid', $data->id());
+    }
+    return $nodes->count()
+      ->execute();
+  }
+
+}

--- a/web/modules/custom/entity_movie/src/ProxyClass/MovieUninstallValidator.php
+++ b/web/modules/custom/entity_movie/src/ProxyClass/MovieUninstallValidator.php
@@ -1,0 +1,81 @@
+<?php
+// phpcs:ignoreFile
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\movie_entity\BookUninstallValidator' "core/modules/book/src".
+ */
+
+namespace Drupal\entity_movie\ProxyClass {
+
+  /**
+   * Provides a proxy class for \Drupal\book\BookUninstallValidator.
+   *
+   * @see \Drupal\Component\ProxyBuilder
+   */
+  class MovieUninstallValidator implements \Drupal\Core\Extension\ModuleUninstallValidatorInterface {
+
+    use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+    /**
+     * The id of the original proxied service.
+     *
+     * @var string
+     */
+    protected $drupalProxyOriginalServiceId;
+
+    /**
+     * The real proxied service, after it was lazy loaded.
+     *
+     * @var \Drupal\book\BookUninstallValidator
+     */
+    protected $service;
+
+    /**
+     * The service container.
+     *
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * Constructs a ProxyClass Drupal proxy object.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     *   The container.
+     * @param string $drupal_proxy_original_service_id
+     *   The service ID of the original service.
+     */
+    public function __construct(\Symfony\Component\DependencyInjection\ContainerInterface $container, $drupal_proxy_original_service_id) {
+      $this->container = $container;
+      $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+    }
+
+    /**
+     * Lazy loads the real service from the container.
+     *
+     * @return object
+     *   Returns the constructed real service.
+     */
+    protected function lazyLoadItself() {
+      if (!isset($this->service)) {
+        $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+      }
+
+      return $this->service;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($module) {
+      return $this->lazyLoadItself()->validate($module);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStringTranslation(\Drupal\Core\StringTranslation\TranslationInterface $translation) {
+      return $this->lazyLoadItself()->setStringTranslation($translation);
+    }
+  }
+}

--- a/web/modules/custom/entity_movie/templates/movie.html.twig
+++ b/web/modules/custom/entity_movie/templates/movie.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Default theme implementation to present a movie entity.
+ *
+ * This template is used when viewing a canonical movie page,
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ *   print a subset such as 'content.label'.
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_movie()
+ */
+#}
+<article{{ attributes }}>
+  {% if view_mode != 'full' %}
+    {{ title_prefix }}
+    {{ title_suffix }}
+  {% endif %}
+  {% if content %}
+    {{- content -}}
+  {% endif %}
+</article>


### PR DESCRIPTION
Task 1:

Create a custom module to create a custom entity type Movie

When the module is enabled, the new entity type should be available under /admin/structure/types }}and {{/node/add to add new nodes from the interface.

The entity type should be created along with fields: Title, Body, Movie Price, Image

Create 3 nodes of this type from the interface.

Task 2:

Create a custom configuration entity type to keep track of award-winning movies by year.

The entities should be editable.

An operation to delete the nodes should be available. Before deleting, a confirmation should be requested from the user.